### PR TITLE
Stop enter key triggering TypeError in search box (issue #181)

### DIFF
--- a/src/resultList.js
+++ b/src/resultList.js
@@ -6,6 +6,7 @@ export default class ResultList {
   constructor({ handleClick = () => {}, classNames = {} } = {}) {
     this.props = { handleClick, classNames };
     this.selected = -1;
+    this.results = [];
 
     const container = createElement('div', cx('results', classNames.container));
     const resultItem = createElement('div', cx(classNames.item));


### PR DESCRIPTION
This bug is triggered by typing a word and hitting enter before the AJAX request returns (depends on internet connection speed).

This fixes the TypeError raised when the results list is still undefined. `this.results` isn't initialised with a default value. When an enter key is hit within a search box, it triggers the `select` method (even if there are no results to select). When `select` references `this.results`, it's still undefined.